### PR TITLE
feat(courses): restrict department field to editor's orgao for course…

### DIFF
--- a/src/app/(private)/(app)/gorio/components/new-course-form.tsx
+++ b/src/app/(private)/(app)/gorio/components/new-course-form.tsx
@@ -813,6 +813,8 @@ interface NewCourseFormProps {
   courseStatus?: string
   onFormChangesDetected?: (hasChanges: boolean) => void
   canPublishDirectly?: boolean
+  /** Restrict orgao_id field to these department ids (for editors) */
+  userOrgaoIds?: string[]
 }
 
 export interface NewCourseFormRef {
@@ -837,6 +839,7 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
       courseStatus,
       onFormChangesDetected,
       canPublishDirectly = false,
+      userOrgaoIds,
     },
     ref
   ) => {
@@ -2261,6 +2264,7 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                         onValueChange={field.onChange}
                         disabled={isReadOnly}
                         placeholder="Selecione um órgão"
+                        restrictToIds={userOrgaoIds}
                       />
                     </FormControl>
                     <FormMessage />

--- a/src/app/(private)/(app)/gorio/courses/course/[course-id]/page.tsx
+++ b/src/app/(private)/(app)/gorio/courses/course/[course-id]/page.tsx
@@ -198,7 +198,8 @@ export default function CourseDetailPage({
   const courseFormRef = useRef<NewCourseFormRef>(null)
 
   // Heimdall user context for role-based actions
-  const { canApproveCourses, canPublishCourses } = useHeimdallUserContext()
+  const { canApproveCourses, canPublishCourses, userOrgaoIds } =
+    useHeimdallUserContext()
 
   // Use the custom hook to fetch course data
   const { course, loading, error, refetch } = useCourse(
@@ -1533,6 +1534,7 @@ export default function CourseDetailPage({
                 courseStatus={course.status as string}
                 onFormChangesDetected={setHasFormChanges}
                 canPublishDirectly={canPublishCourses}
+                userOrgaoIds={!canPublishCourses ? userOrgaoIds : undefined}
               />
             </div>
           </div>
@@ -1570,6 +1572,7 @@ export default function CourseDetailPage({
                   isDraft={isDraft}
                   courseStatus={course.status as string}
                   onFormChangesDetected={setHasFormChanges}
+                  userOrgaoIds={!canPublishCourses ? userOrgaoIds : undefined}
                 />
               </div>
             </TabsContent>

--- a/src/app/(private)/(app)/gorio/courses/new/page.tsx
+++ b/src/app/(private)/(app)/gorio/courses/new/page.tsx
@@ -21,7 +21,7 @@ export default function NewCourse() {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const router = useRouter()
-  const { canPublishCourses } = useHeimdallUserContext()
+  const { canPublishCourses, userOrgaoIds } = useHeimdallUserContext()
 
   const handleCreateCourse = async (data: any) => {
     try {
@@ -175,6 +175,7 @@ export default function NewCourse() {
           }}
           onFormChangesDetected={setHasUnsavedChanges}
           canPublishDirectly={canPublishCourses}
+          userOrgaoIds={!canPublishCourses ? userOrgaoIds : undefined}
         />
       </div>
 

--- a/src/components/ui/department-combobox.tsx
+++ b/src/components/ui/department-combobox.tsx
@@ -32,6 +32,8 @@ interface DepartmentComboboxProps {
   placeholder?: string
   className?: string
   clearButtonSize?: string
+  /** When set, restricts the combobox to only these department cd_ua ids */
+  restrictToIds?: string[]
 }
 
 export function DepartmentCombobox({
@@ -41,7 +43,9 @@ export function DepartmentCombobox({
   placeholder = 'Selecione um órgão',
   className,
   clearButtonSize = 'h-9! w-9!',
+  restrictToIds,
 }: DepartmentComboboxProps) {
+  const isRestricted = restrictToIds && restrictToIds.length > 0
   const [open, setOpen] = React.useState(false)
   const [departments, setDepartments] = React.useState<Department[]>([])
   const [loading, setLoading] = React.useState(false)
@@ -57,6 +61,51 @@ export function DepartmentCombobox({
     React.useState<Department | null>(null)
   const [selectedDepartmentLoaded, setSelectedDepartmentLoaded] =
     React.useState(false)
+
+  // Fetch restricted departments by id and auto-select if only one
+  React.useEffect(() => {
+    if (!isRestricted) return
+
+    let isCancelled = false
+
+    const fetchRestricted = async () => {
+      setLoading(true)
+      try {
+        const results = await Promise.all(
+          restrictToIds.map(async id => {
+            const res = await fetch(`/api/departments/${id}`)
+            if (res.ok) {
+              const data = await res.json()
+              return data.data as Department | null
+            }
+            return null
+          })
+        )
+        if (isCancelled) return
+
+        const valid = results.filter(Boolean) as Department[]
+        setDepartments(valid)
+        setHasMore(false)
+
+        // Auto-select if only one department
+        if (valid.length === 1 && !value) {
+          onValueChange(valid[0].cd_ua)
+          setSelectedDepartment(valid[0])
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          console.error('Error fetching restricted departments:', error)
+        }
+      } finally {
+        if (!isCancelled) setLoading(false)
+      }
+    }
+
+    fetchRestricted()
+    return () => {
+      isCancelled = true
+    }
+  }, [isRestricted, restrictToIds, value, onValueChange])
 
   // Fetch departments
   const fetchDepartments = React.useCallback(
@@ -153,13 +202,14 @@ export function DepartmentCombobox({
     }
   }, [loading, hasMore, page, search, fetchDepartments])
 
-  // Initial load
+  // Initial load (skip if restricted — already fetched by restrictToIds effect)
   React.useEffect(() => {
+    if (isRestricted) return
     if (open) {
       setPage(1)
       fetchDepartments(1, '')
     }
-  }, [open, fetchDepartments])
+  }, [open, fetchDepartments, isRestricted])
 
   // Fetch selected department details when value changes
   React.useEffect(() => {
@@ -257,7 +307,7 @@ export function DepartmentCombobox({
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            disabled={disabled}
+            disabled={disabled || (isRestricted && restrictToIds.length === 1)}
             className={cn(
               'truncate! relative! overflow-hidden! flex-1 justify-between text-left min-w-0 w-full',
               !value && 'text-muted-foreground',
@@ -355,7 +405,7 @@ export function DepartmentCombobox({
           </Command>
         </PopoverContent>
       </Popover>
-      {value && (
+      {value && !(isRestricted && restrictToIds.length === 1) && (
         <Button
           variant="outline"
           size="icon"

--- a/src/contexts/heimdall-user-context.tsx
+++ b/src/contexts/heimdall-user-context.tsx
@@ -58,6 +58,8 @@ interface HeimdallUserContextType {
   canDeleteOwnDraft: boolean
   /** Can manage enrollments (approve/reject/complete) */
   canManageEnrollments: boolean
+  /** Orgao IDs extracted from user groups (go:orgao:{id}) */
+  userOrgaoIds: string[]
 }
 
 const HeimdallUserContext = createContext<HeimdallUserContextType | null>(null)
@@ -84,6 +86,9 @@ export function HeimdallUserProvider({ children }: { children: ReactNode }) {
   const canEditCoursesPermission = canEditCourses(user?.roles)
   const canDeleteDraft = canDeleteOwnDraft(user?.roles)
   const canManageEnrollmentsPermission = canManageEnrollments(user?.roles)
+  const orgaoIds = (user?.groups || [])
+    .filter(g => g.startsWith('go:orgao:'))
+    .map(g => g.replace('go:orgao:', ''))
 
   return (
     <HeimdallUserContext.Provider
@@ -109,6 +114,7 @@ export function HeimdallUserProvider({ children }: { children: ReactNode }) {
         canEditCourses: canEditCoursesPermission,
         canDeleteOwnDraft: canDeleteDraft,
         canManageEnrollments: canManageEnrollmentsPermission,
+        userOrgaoIds: orgaoIds,
       }}
     >
       {children}


### PR DESCRIPTION
… creation

Editors can only select departments from their Heimdall go:orgao groups. Auto-selects and locks the field when editor has a single orgao. Admin/casa_civil retains unrestricted department selection.