### PR TITLE
feat: update route permissions for empresas module

### DIFF
--- a/src/app/(private)/(app)/gorio/empregabilidade/empresas/page.tsx
+++ b/src/app/(private)/(app)/gorio/empregabilidade/empresas/page.tsx
@@ -80,7 +80,7 @@ function formatCNPJ(cnpj: string): string {
  * - Create new empresa button
  *
  * PERMISSIONS:
- * - Route: admin, superadmin, go:admin, go:empregabilidade:admin, go:empregabilidade:editor_sem_curadoria (editor_com_curadoria blocked by middleware)
+ * - Route: admin, superadmin, go:admin, go:empregabilidade:admin, go:empregabilidade:editor_sem_curadoria, go:empregabilidade:editor_com_curadoria
  * - Edit/Delete/Create: canManageEmpresasInEmpregabilidade (same as route access)
  */
 

--- a/src/lib/route-permissions.ts
+++ b/src/lib/route-permissions.ts
@@ -37,7 +37,7 @@ export const ROUTE_PERMISSIONS: Record<string, string[]> = {
   // GO Rio - Empregabilidade (admin, superadmin, go:admin + 3 empregabilidade roles)
   '/gorio/empregabilidade': [...EMPREGO_TRABALHO_ROLES],
   '/gorio/empregabilidade/new': [...EMPREGO_TRABALHO_ROLES],
-  // Empresas: editor_com_curadoria cannot create/edit - list and new must be before /* so they match first
+  // Empresas: list and new must be before /* so they match first
   '/gorio/empregabilidade/empresas': [
     'admin',
     'superadmin',
@@ -52,6 +52,7 @@ export const ROUTE_PERMISSIONS: Record<string, string[]> = {
     'go:admin',
     'go:empregabilidade:admin',
     'go:empregabilidade:editor_sem_curadoria',
+    'go:empregabilidade:editor_com_curadoria',
   ],
   '/gorio/empregabilidade/empresas/*': [
     'admin',

--- a/src/types/heimdall-roles.ts
+++ b/src/types/heimdall-roles.ts
@@ -171,13 +171,20 @@ export function canFreezeOrDiscontinueVaga(
 
 /**
  * Can create/edit empresas within the empregabilidade module.
- * editor_com_curadoria cannot.
  */
 export function canManageEmpresasInEmpregabilidade(
   roles: string[] | undefined
 ): boolean {
   if (!roles) return false
-  return !hasEditorComCuradoriaRestrictions(roles)
+  const EMPRESA_ROLES = [
+    'admin',
+    'superadmin',
+    'go:admin',
+    'go:empregabilidade:admin',
+    'go:empregabilidade:editor_sem_curadoria',
+    'go:empregabilidade:editor_com_curadoria',
+  ]
+  return roles.some(r => EMPRESA_ROLES.includes(r))
 }
 
 /**


### PR DESCRIPTION
- Added 'go:empregabilidade:editor_com_curadoria' role to the empresas route permissions.
- Updated documentation to reflect the new permissions for creating and managing empresas.
- Enhanced the canManageEmpresasInEmpregabilidade function to include the new role.