### PR TITLE
Fix/jr 199/adjusts courses

### DIFF
--- a/src/app/(private)/(app)/gorio/components/class-days-picker.tsx
+++ b/src/app/(private)/(app)/gorio/components/class-days-picker.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { useEffect, useRef, useState } from 'react'
+import {
+  DAYS_ORDER,
+  parseClassDays,
+  serializeClassDays,
+} from './schedule-utils'
+
+interface ClassDaysPickerProps {
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+export function ClassDaysPicker({
+  value,
+  onChange,
+  disabled,
+}: ClassDaysPickerProps) {
+  const legacyRef = useRef<string>('')
+  const mountedRef = useRef(false)
+  const [legacyDetected, setLegacyDetected] = useState(false)
+
+  // Detect legacy value on mount only — capture initialValue before any onChange fires
+  const initialValueRef = useRef(value)
+  useEffect(() => {
+    if (mountedRef.current) return
+    mountedRef.current = true
+    const initial = initialValueRef.current
+    if (!initial) return
+    const parsed = parseClassDays(initial)
+    if (parsed.size === 0) {
+      legacyRef.current = initial
+      setLegacyDetected(true)
+    }
+  }, []) // intentionally empty — runs once on mount using captured initialValueRef
+
+  const selected = parseClassDays(value)
+  // If value is legacy, selected will be empty — checkboxes show unchecked, correct.
+  // The actual checked state derives from the current form value after user interaction.
+  const hasNewValue = selected.size > 0
+
+  function toggle(day: string) {
+    const next = new Set(selected)
+    if (next.has(day)) {
+      next.delete(day)
+    } else {
+      next.add(day)
+    }
+    const serialized = serializeClassDays(next)
+    // Protect: if user deselects all and there's a legacy value, preserve legacy
+    if (!serialized && legacyRef.current) {
+      onChange(legacyRef.current)
+      return
+    }
+    onChange(serialized)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-4">
+        {DAYS_ORDER.map(day => {
+          const id = `day-checkbox-${day}`
+          return (
+            <div key={day} className="flex items-center gap-2">
+              <Checkbox
+                id={id}
+                checked={selected.has(day)}
+                onCheckedChange={() => toggle(day)}
+                disabled={disabled}
+              />
+              <Label htmlFor={id} className="cursor-pointer font-medium">
+                {day}
+              </Label>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Legacy value badge */}
+      {legacyDetected && (
+        <div className="flex items-center gap-2 rounded-md border border-amber-500/25 bg-amber-500/5 px-3 py-2">
+          <span className="shrink-0 text-xs font-medium text-amber-500/70">
+            Valor atual (formatação antiga)
+          </span>
+          <span className="truncate text-sm text-amber-200/60">
+            {legacyRef.current}
+          </span>
+        </div>
+      )}
+
+      {/* New value preview + replacement warning */}
+      {hasNewValue && (
+        <>
+          <input
+            readOnly
+            value={value}
+            tabIndex={-1}
+            className="h-9 w-full cursor-default select-none rounded-md border border-input bg-muted px-3 py-1 text-sm text-muted-foreground shadow-sm"
+          />
+          {legacyDetected && (
+            <p className="text-xs text-amber-500/70">
+              ⚠ Este novo valor substituirá a formatação antiga ao salvar.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/app/(private)/(app)/gorio/components/new-course-form.tsx
+++ b/src/app/(private)/(app)/gorio/components/new-course-form.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
@@ -59,7 +60,9 @@ import { getCachedCategorias, setCachedCategorias } from '@/lib/categoria-utils'
 import { neighborhoodZone } from '@/lib/neighborhood_zone'
 import { Copy, Plus, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { ClassDaysPicker } from './class-days-picker'
 import { type CustomField, FieldsCreator } from './fields-creator'
+import { ScheduleTimeBuilder } from './schedule-time-builder'
 
 export type Accessibility = 'ACESSIVEL' | 'EXCLUSIVO'
 const ACCESSIBILITY_OPTIONS: Accessibility[] = [
@@ -505,72 +508,91 @@ const fullFormSchema = z
     message: 'A data final deve ser igual ou posterior à data inicial.',
     path: ['enrollment_end_date'],
   })
-  .refine(
-    data => {
-      if (data.modalidade === 'ONLINE') {
-        return data.remote_class.every(schedule => {
-          const hasStartDate = !!schedule.classStartDate
-          const hasEndDate = !!schedule.classEndDate
-
-          // Both dates must be either filled or empty (not mixed)
-          if (hasStartDate !== hasEndDate) {
-            return false
-          }
-
-          // If both are empty, it's valid
-          if (!hasStartDate && !hasEndDate) {
-            return true
-          }
-
-          // If both are filled, validate the date range
-          if (
-            hasStartDate &&
-            hasEndDate &&
-            schedule.classStartDate &&
-            schedule.classEndDate
+  .superRefine((data, ctx) => {
+    if (data.modalidade === 'LIVRE_FORMACAO_ONLINE') return
+    const msg =
+      'A data final das aulas deve ser igual ou posterior à data inicial.'
+    if (data.modalidade === 'ONLINE') {
+      data.remote_class.forEach((schedule, i) => {
+        const hasStart = !!schedule.classStartDate
+        const hasEnd = !!schedule.classEndDate
+        if (hasStart !== hasEnd) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Preencha as duas datas de aula ou deixe ambas em branco.',
+            path: ['remote_class', i, 'classEndDate'],
+          })
+        } else if (
+          hasStart &&
+          hasEnd &&
+          schedule.classEndDate! < schedule.classStartDate!
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: msg,
+            path: ['remote_class', i, 'classEndDate'],
+          })
+        }
+      })
+    } else {
+      data.locations.forEach((location, li) => {
+        location.schedules.forEach((schedule, si) => {
+          const hasStart = !!schedule.classStartDate
+          const hasEnd = !!schedule.classEndDate
+          if (hasStart !== hasEnd) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message:
+                'Preencha as duas datas de aula ou deixe ambas em branco.',
+              path: ['locations', li, 'schedules', si, 'classEndDate'],
+            })
+          } else if (
+            hasStart &&
+            hasEnd &&
+            schedule.classEndDate < schedule.classStartDate
           ) {
-            return schedule.classEndDate >= schedule.classStartDate
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: msg,
+              path: ['locations', li, 'schedules', si, 'classEndDate'],
+            })
           }
-          return true
         })
-      }
-      if (data.modalidade === 'LIVRE_FORMACAO_ONLINE') {
-        return true // Não precisa validar datas para livre formação
-      }
-      return data.locations.every(location =>
-        location.schedules.every(schedule => {
-          const hasStartDate = !!schedule.classStartDate
-          const hasEndDate = !!schedule.classEndDate
-
-          // Both dates must be either filled or empty (not mixed)
-          if (hasStartDate !== hasEndDate) {
-            return false
-          }
-
-          // If both are empty, it's valid
-          if (!hasStartDate && !hasEndDate) {
-            return true
-          }
-
-          // If both are filled, validate the date range
-          if (
-            hasStartDate &&
-            hasEndDate &&
-            schedule.classStartDate &&
-            schedule.classEndDate
-          ) {
-            return schedule.classEndDate >= schedule.classStartDate
-          }
-          return true
-        })
-      )
-    },
-    {
-      message:
-        'A data final das aulas deve ser igual ou posterior à data inicial.',
-      path: ['modalidade'],
+      })
     }
-  )
+  })
+  .superRefine((data, ctx) => {
+    if (data.modalidade === 'LIVRE_FORMACAO_ONLINE') return
+    const msg =
+      'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+    if (data.modalidade === 'ONLINE') {
+      data.remote_class.forEach((schedule, i) => {
+        if (
+          schedule.classStartDate &&
+          schedule.classStartDate < data.enrollment_start_date
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: msg,
+            path: ['remote_class', i, 'classStartDate'],
+          })
+        }
+      })
+    } else {
+      // PRESENCIAL
+      data.locations.forEach((location, li) => {
+        location.schedules.forEach((schedule, si) => {
+          if (schedule.classStartDate < data.enrollment_start_date) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: msg,
+              path: ['locations', li, 'schedules', si, 'classStartDate'],
+            })
+          }
+        })
+      })
+    }
+  })
   .refine(
     data => {
       if (data.course_management_type === 'OWN_ORG') return true
@@ -594,99 +616,202 @@ const fullFormSchema = z
   )
 
 // Create a minimal schema for draft validation (only basic field presence)
-const draftFormSchema = z.object({
-  title: z.string().optional(),
-  description: z.string().optional(),
-  category: z.array(z.number()).optional(),
-  enrollment_start_date: z.date().optional(),
-  enrollment_end_date: z.date().optional(),
-  orgao_id: z.string().optional(),
-  modalidade: z
-    .enum(['PRESENCIAL', 'ONLINE', 'LIVRE_FORMACAO_ONLINE'])
-    .optional(),
-  workload: z.string().optional(),
-  target_audience: z.string().optional(),
-  theme: z.enum(['Curso', 'Palestra', 'Oficina', 'Workshop']).optional(),
-  institutional_logo: z
-    .string()
-    .refine(validateGoogleCloudStorageURL, {
-      message:
-        'Logo institucional deve ser uma URL do bucket do Google Cloud Storage.',
-    })
-    .optional(),
-  cover_image: z
-    .string()
-    .refine(validateGoogleCloudStorageURL, {
-      message:
-        'Imagem de capa deve ser uma URL do bucket do Google Cloud Storage.',
-    })
-    .optional(),
-  pre_requisitos: z.string().optional(),
-  has_certificate: z.boolean().optional(),
+const draftFormSchema = z
+  .object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    category: z.array(z.number()).optional(),
+    enrollment_start_date: z.date().optional(),
+    enrollment_end_date: z.date().optional(),
+    orgao_id: z.string().optional(),
+    modalidade: z
+      .enum(['PRESENCIAL', 'ONLINE', 'LIVRE_FORMACAO_ONLINE'])
+      .optional(),
+    workload: z.string().optional(),
+    target_audience: z.string().optional(),
+    theme: z.enum(['Curso', 'Palestra', 'Oficina', 'Workshop']).optional(),
+    institutional_logo: z
+      .string()
+      .refine(validateGoogleCloudStorageURL, {
+        message:
+          'Logo institucional deve ser uma URL do bucket do Google Cloud Storage.',
+      })
+      .optional(),
+    cover_image: z
+      .string()
+      .refine(validateGoogleCloudStorageURL, {
+        message:
+          'Imagem de capa deve ser uma URL do bucket do Google Cloud Storage.',
+      })
+      .optional(),
+    pre_requisitos: z.string().optional(),
+    has_certificate: z.boolean().optional(),
 
-  // Course management type
-  course_management_type: z
-    .enum(['OWN_ORG', 'EXTERNAL_MANAGED_BY_ORG', 'EXTERNAL_MANAGED_BY_PARTNER'])
-    .optional(),
-  // External partner fields
-  external_partner_name: z.string().optional(),
-  external_partner_url: z.string().optional(),
-  external_partner_logo_url: z
-    .string()
-    .refine(validateGoogleCloudStorageURL, {
-      message:
-        'Logo do parceiro externo deve ser uma URL do bucket do Google Cloud Storage.',
-    })
-    .optional(),
-  external_partner_contact: z.string().optional(),
+    // Course management type
+    course_management_type: z
+      .enum([
+        'OWN_ORG',
+        'EXTERNAL_MANAGED_BY_ORG',
+        'EXTERNAL_MANAGED_BY_PARTNER',
+      ])
+      .optional(),
+    // External partner fields
+    external_partner_name: z.string().optional(),
+    external_partner_url: z.string().optional(),
+    external_partner_logo_url: z
+      .string()
+      .refine(validateGoogleCloudStorageURL, {
+        message:
+          'Logo do parceiro externo deve ser uma URL do bucket do Google Cloud Storage.',
+      })
+      .optional(),
+    external_partner_contact: z.string().optional(),
 
-  facilitator: z.string().optional(),
-  objectives: z.string().optional(),
-  expected_results: z.string().optional(),
-  program_content: z.string().optional(),
-  methodology: z.string().optional(),
-  resources_used: z.string().optional(),
-  material_used: z.string().optional(),
-  teaching_material: z.string().optional(),
-  is_visible: z.boolean().optional(),
-  auto_approve_enrollments: z.boolean().optional(),
-  formacao_link: z.string().url().optional().or(z.literal('')),
-  custom_fields: customFieldsSchema,
-  locations: z
-    .array(
-      z.object({
-        id: z.string().optional(),
-        address: z.string().optional(),
-        neighborhood: z.string().optional(),
-        zona: z.string().optional(),
-        schedules: z
-          .array(
-            z.object({
-              id: z.string().optional(),
-              vacancies: z.number().optional(),
-              classStartDate: z.date().optional(),
-              classEndDate: z.date().optional(),
-              classTime: z.string().optional(),
-              classDays: z.string().optional(),
+    facilitator: z.string().optional(),
+    objectives: z.string().optional(),
+    expected_results: z.string().optional(),
+    program_content: z.string().optional(),
+    methodology: z.string().optional(),
+    resources_used: z.string().optional(),
+    material_used: z.string().optional(),
+    teaching_material: z.string().optional(),
+    is_visible: z.boolean().optional(),
+    auto_approve_enrollments: z.boolean().optional(),
+    formacao_link: z.string().url().optional().or(z.literal('')),
+    custom_fields: customFieldsSchema,
+    locations: z
+      .array(
+        z.object({
+          id: z.string().optional(),
+          address: z.string().optional(),
+          neighborhood: z.string().optional(),
+          zona: z.string().optional(),
+          schedules: z
+            .array(
+              z.object({
+                id: z.string().optional(),
+                vacancies: z.number().optional(),
+                classStartDate: z.date().optional(),
+                classEndDate: z.date().optional(),
+                classTime: z.string().optional(),
+                classDays: z.string().optional(),
+              })
+            )
+            .optional(),
+        })
+      )
+      .optional(),
+    remote_class: z
+      .array(
+        z.object({
+          id: z.string().optional(),
+          vacancies: z.number().optional(),
+          classStartDate: z.date().optional().nullable(),
+          classEndDate: z.date().optional().nullable(),
+          classTime: z.string().optional().nullable(),
+          classDays: z.string().optional().nullable(),
+        })
+      )
+      .optional(),
+  })
+  .refine(
+    data => {
+      // Só valida se ambas as datas de inscrição estiverem presentes
+      if (!data.enrollment_start_date) return true
+
+      // Verifica turmas presenciais (locations)
+      if (data.locations) {
+        for (const location of data.locations) {
+          for (const schedule of location.schedules ?? []) {
+            if (
+              schedule.classStartDate &&
+              schedule.classStartDate < data.enrollment_start_date
+            ) {
+              return false
+            }
+          }
+        }
+      }
+
+      // Verifica turmas online (remote_class)
+      if (data.remote_class) {
+        for (const schedule of data.remote_class) {
+          if (
+            schedule.classStartDate &&
+            schedule.classStartDate < data.enrollment_start_date
+          ) {
+            return false
+          }
+        }
+      }
+
+      return true
+    },
+    {
+      message:
+        'A data de início das aulas deve ser igual ou posterior ao início das inscrições.',
+      path: ['modalidade'],
+    }
+  )
+  .superRefine((data, ctx) => {
+    if (!data.enrollment_start_date) return
+    const msgStart =
+      'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+    const msgEnd =
+      'A data final das aulas deve ser igual ou posterior à data inicial.'
+    if (data.locations) {
+      data.locations.forEach((location, li) => {
+        ;(location.schedules ?? []).forEach((schedule, si) => {
+          if (
+            schedule.classStartDate &&
+            schedule.classStartDate < data.enrollment_start_date!
+          ) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: msgStart,
+              path: ['locations', li, 'schedules', si, 'classStartDate'],
             })
-          )
-          .optional(),
+          }
+          if (
+            schedule.classStartDate &&
+            schedule.classEndDate &&
+            schedule.classEndDate < schedule.classStartDate
+          ) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: msgEnd,
+              path: ['locations', li, 'schedules', si, 'classEndDate'],
+            })
+          }
+        })
       })
-    )
-    .optional(),
-  remote_class: z
-    .array(
-      z.object({
-        id: z.string().optional(),
-        vacancies: z.number().optional(),
-        classStartDate: z.date().optional().nullable(),
-        classEndDate: z.date().optional().nullable(),
-        classTime: z.string().optional().nullable(),
-        classDays: z.string().optional().nullable(),
+    }
+    if (data.remote_class) {
+      data.remote_class.forEach((schedule, i) => {
+        if (
+          schedule.classStartDate &&
+          schedule.classStartDate < data.enrollment_start_date!
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: msgStart,
+            path: ['remote_class', i, 'classStartDate'],
+          })
+        }
+        if (
+          schedule.classStartDate &&
+          schedule.classEndDate &&
+          schedule.classEndDate < schedule.classStartDate
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: msgEnd,
+            path: ['remote_class', i, 'classEndDate'],
+          })
+        }
       })
-    )
-    .optional(),
-})
+    }
+  })
 
 // Use the full schema as the main form schema for form validation display
 const formSchema = fullFormSchema
@@ -874,10 +999,12 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
       const uniqueNeighborhoods = Array.from(
         new Set(neighborhoodZone.map(n => n.bairro))
       )
-      return uniqueNeighborhoods.sort().map(bairro => ({
-        value: bairro,
-        label: bairro,
-      }))
+      return uniqueNeighborhoods
+        .sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }))
+        .map(bairro => ({
+          value: bairro,
+          label: bairro,
+        }))
     }, [])
 
     const instituicaoId = Number(
@@ -1141,6 +1268,25 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
     const modalidade = form.watch('modalidade')
     const courseManagementType = form.watch('course_management_type')
     const externalPartnerUrl = form.watch('external_partner_url')
+    const enrollmentStartDate = form.watch('enrollment_start_date')
+
+    // Reset form when initialData changes (e.g. after a save + refetch cycle).
+    // Skip the first render — defaultValues already consumed initialData at that point.
+    const prevInitialDataRef = useRef(initialData)
+    // biome-ignore lint/correctness/useExhaustiveDependencies: prevInitialDataRef is a stable ref; form.reset and prepareDefaultValues are stable (RHF + useCallback)
+    useEffect(() => {
+      if (prevInitialDataRef.current === initialData) return
+      prevInitialDataRef.current = initialData
+      if (!initialData) return
+      form.reset(prepareDefaultValues(initialData), {
+        keepErrors: false,
+        keepDirty: false,
+        keepIsSubmitted: false,
+        keepTouched: false,
+        keepIsValid: false,
+        keepSubmitCount: false,
+      })
+    }, [initialData])
 
     // Track form changes for unsaved changes guard
     const isDirty = form.formState.isDirty
@@ -1189,6 +1335,62 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
         }
       }
     }, [modalidade, externalPartnerUrl, form])
+
+    // Quando enrollment_start_date muda, corrige automaticamente datas de aula que ficaram inválidas
+    useEffect(() => {
+      if (!enrollmentStartDate) return
+      const values = form.getValues()
+
+      values.locations?.forEach((loc, li) => {
+        ;(loc.schedules ?? []).forEach((sched, si) => {
+          if (
+            sched.classStartDate &&
+            sched.classStartDate < enrollmentStartDate
+          ) {
+            form.setValue(
+              `locations.${li}.schedules.${si}.classStartDate`,
+              enrollmentStartDate,
+              { shouldValidate: true }
+            )
+            // se classEndDate também ficou antes da nova data de inscrição
+            if (
+              sched.classEndDate &&
+              sched.classEndDate < enrollmentStartDate
+            ) {
+              form.setValue(
+                `locations.${li}.schedules.${si}.classEndDate`,
+                enrollmentStartDate,
+                { shouldValidate: true }
+              )
+            }
+          }
+        })
+      })
+
+      values.remote_class?.forEach((sched, i) => {
+        if (
+          sched.classStartDate &&
+          sched.classStartDate < enrollmentStartDate
+        ) {
+          form.setValue(
+            `remote_class.${i}.classStartDate`,
+            enrollmentStartDate,
+            {
+              shouldValidate: true,
+            }
+          )
+          if (sched.classEndDate && sched.classEndDate < enrollmentStartDate) {
+            form.setValue(
+              `remote_class.${i}.classEndDate`,
+              enrollmentStartDate,
+              {
+                shouldValidate: true,
+              }
+            )
+          }
+        }
+      })
+    }, [enrollmentStartDate, form])
 
     // UseFieldArray for locations (PRESENCIAL/HIBRIDO)
     const { fields, append, remove } = useFieldArray({
@@ -1466,8 +1668,8 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                         vacancies: 1,
                         classStartDate: currentDate,
                         classEndDate: nextMonth,
-                        classTime: 'Horário em definição',
-                        classDays: 'Dias em definição',
+                        classTime: '',
+                        classDays: '',
                       },
                     ],
                   },
@@ -2036,9 +2238,9 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
       } catch (error) {
         if (error instanceof z.ZodError) {
           console.error('Validation errors:', error.errors)
+          const errorMessage = formatValidationErrors(error)
           toast.error('Erro ao salvar rascunho', {
-            description:
-              'Ocorreu um erro de formato nos dados. Verifique os campos preenchidos e tente novamente.',
+            description: errorMessage,
             duration: 5000,
           })
           // Close dialog on validation error
@@ -2204,7 +2406,19 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                       <FormControl>
                         <DateTimePicker
                           value={field.value || undefined}
-                          onChange={field.onChange}
+                          onChange={date => {
+                            field.onChange(date)
+                            if (date) {
+                              const endDate = form.getValues(
+                                'enrollment_end_date'
+                              )
+                              if (endDate && endDate < date) {
+                                form.setValue('enrollment_end_date', date, {
+                                  shouldValidate: true,
+                                })
+                              }
+                            }
+                          }}
                           placeholder="Selecionar data e hora de início"
                           disabled={isReadOnly}
                         />
@@ -2225,6 +2439,7 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                           onChange={field.onChange}
                           placeholder="Selecionar data e hora de fim"
                           disabled={isReadOnly}
+                          minDate={enrollmentStartDate || undefined}
                         />
                       </FormControl>
                       <FormMessage />
@@ -2721,9 +2936,26 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                                     <FormControl>
                                       <DateTimePicker
                                         value={field.value || undefined}
-                                        onChange={field.onChange}
+                                        onChange={date => {
+                                          field.onChange(date)
+                                          if (date) {
+                                            const endDate = form.getValues(
+                                              `remote_class.${index}.classEndDate`
+                                            )
+                                            if (endDate && endDate < date) {
+                                              form.setValue(
+                                                `remote_class.${index}.classEndDate`,
+                                                date,
+                                                { shouldValidate: true }
+                                              )
+                                            }
+                                          }
+                                        }}
                                         placeholder="Selecionar data e hora de início"
                                         disabled={isReadOnly}
+                                        minDate={
+                                          enrollmentStartDate || undefined
+                                        }
                                       />
                                     </FormControl>
                                     <FormMessage />
@@ -2742,6 +2974,11 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                                         onChange={field.onChange}
                                         placeholder="Selecionar data e hora de fim"
                                         disabled={isReadOnly}
+                                        minDate={
+                                          form.watch(
+                                            `remote_class.${index}.classStartDate`
+                                          ) || undefined
+                                        }
                                       />
                                     </FormControl>
                                     <FormMessage />
@@ -2752,15 +2989,15 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
 
                             <FormField
                               control={form.control}
-                              name={`remote_class.${index}.classTime`}
+                              name={`remote_class.${index}.classDays`}
                               render={({ field }) => (
                                 <FormItem>
-                                  <FormLabel>Horário das aulas</FormLabel>
+                                  <FormLabel>Dias de aula</FormLabel>
                                   <FormControl>
-                                    <Input
-                                      placeholder="Digite o horário das aulas (ex: 19:00 - 22:00, Manhã, Tarde, Noite, etc.)"
+                                    <ClassDaysPicker
                                       value={field.value || ''}
                                       onChange={field.onChange}
+                                      disabled={isReadOnly}
                                     />
                                   </FormControl>
                                   <FormMessage />
@@ -2770,15 +3007,20 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
 
                             <FormField
                               control={form.control}
-                              name={`remote_class.${index}.classDays`}
+                              name={`remote_class.${index}.classTime`}
                               render={({ field }) => (
-                                <FormItem>
-                                  <FormLabel>Dias de aula</FormLabel>
+                                <FormItem className="pt-2">
+                                  <FormLabel>Horário das aulas</FormLabel>
                                   <FormControl>
-                                    <Input
-                                      placeholder="Digite os dias das aulas (ex: Segunda, Quarta e Sexta, Segunda a Sexta, etc.)"
+                                    <ScheduleTimeBuilder
                                       value={field.value || ''}
                                       onChange={field.onChange}
+                                      classDays={
+                                        form.watch(
+                                          `remote_class.${index}.classDays`
+                                        ) || ''
+                                      }
+                                      disabled={isReadOnly}
                                     />
                                   </FormControl>
                                   <FormMessage />
@@ -3039,9 +3281,31 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                                             <FormControl>
                                               <DateTimePicker
                                                 value={field.value}
-                                                onChange={field.onChange}
+                                                onChange={date => {
+                                                  field.onChange(date)
+                                                  if (date) {
+                                                    const endDate =
+                                                      form.getValues(
+                                                        `locations.${index}.schedules.${scheduleIndex}.classEndDate`
+                                                      )
+                                                    if (
+                                                      endDate &&
+                                                      endDate < date
+                                                    ) {
+                                                      form.setValue(
+                                                        `locations.${index}.schedules.${scheduleIndex}.classEndDate`,
+                                                        date,
+                                                        { shouldValidate: true }
+                                                      )
+                                                    }
+                                                  }
+                                                }}
                                                 placeholder="Selecionar data e hora de início"
                                                 disabled={isReadOnly}
+                                                minDate={
+                                                  enrollmentStartDate ||
+                                                  undefined
+                                                }
                                               />
                                             </FormControl>
                                             <FormMessage />
@@ -3062,6 +3326,11 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
                                                 onChange={field.onChange}
                                                 placeholder="Selecionar data e hora de fim"
                                                 disabled={isReadOnly}
+                                                minDate={
+                                                  form.watch(
+                                                    `locations.${index}.schedules.${scheduleIndex}.classStartDate`
+                                                  ) || undefined
+                                                }
                                               />
                                             </FormControl>
                                             <FormMessage />
@@ -3072,16 +3341,15 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
 
                                     <FormField
                                       control={form.control}
-                                      name={`locations.${index}.schedules.${scheduleIndex}.classTime`}
+                                      name={`locations.${index}.schedules.${scheduleIndex}.classDays`}
                                       render={({ field }) => (
                                         <FormItem>
-                                          <FormLabel>
-                                            Horário das aulas*
-                                          </FormLabel>
+                                          <FormLabel>Dias de aula*</FormLabel>
                                           <FormControl>
-                                            <Input
-                                              placeholder="Digite o horário das aulas (ex: 19:00 - 22:00, Manhã, Tarde, Noite, etc.)"
-                                              {...field}
+                                            <ClassDaysPicker
+                                              value={field.value || ''}
+                                              onChange={field.onChange}
+                                              disabled={isReadOnly}
                                             />
                                           </FormControl>
                                           <FormMessage />
@@ -3091,14 +3359,22 @@ export const NewCourseForm = forwardRef<NewCourseFormRef, NewCourseFormProps>(
 
                                     <FormField
                                       control={form.control}
-                                      name={`locations.${index}.schedules.${scheduleIndex}.classDays`}
+                                      name={`locations.${index}.schedules.${scheduleIndex}.classTime`}
                                       render={({ field }) => (
-                                        <FormItem>
-                                          <FormLabel>Dias de aula*</FormLabel>
+                                        <FormItem className="pt-2">
+                                          <FormLabel>
+                                            Horário das aulas*
+                                          </FormLabel>
                                           <FormControl>
-                                            <Input
-                                              placeholder="Digite os dias das aulas (ex: Segunda, Quarta e Sexta, Segunda a Sexta, etc.)"
-                                              {...field}
+                                            <ScheduleTimeBuilder
+                                              value={field.value || ''}
+                                              onChange={field.onChange}
+                                              classDays={
+                                                form.watch(
+                                                  `locations.${index}.schedules.${scheduleIndex}.classDays`
+                                                ) || ''
+                                              }
+                                              disabled={isReadOnly}
                                             />
                                           </FormControl>
                                           <FormMessage />

--- a/src/app/(private)/(app)/gorio/components/schedule-time-builder.tsx
+++ b/src/app/(private)/(app)/gorio/components/schedule-time-builder.tsx
@@ -1,0 +1,366 @@
+'use client'
+
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useEffect, useRef, useState } from 'react'
+import {
+  DAYS_ORDER,
+  type DayTimeEntry,
+  parseClassDays,
+  parseClassTime,
+  serializePerDayTimes,
+  serializeSameTime,
+} from './schedule-utils'
+
+type ScheduleMode = 'same' | 'different'
+
+interface ScheduleTimeBuilderProps {
+  value: string | null | undefined
+  onChange: (value: string) => void
+  classDays: string | null | undefined
+  disabled?: boolean
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'))
+const MINUTES = ['00', '15', '30', '45']
+
+interface TimeSelectProps {
+  value: string // "HH:MM"
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+function TimeSelect({ value, onChange, disabled }: TimeSelectProps) {
+  const parts = value ? value.split(':') : ['', '']
+  const h = parts[0] || ''
+  const m = parts[1] || '00'
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Select
+        value={h}
+        onValueChange={newH => onChange(`${newH}:${m}`)}
+        disabled={disabled}
+      >
+        <SelectTrigger className="h-8 w-[76px]">
+          <SelectValue placeholder="hh" />
+        </SelectTrigger>
+        <SelectContent>
+          {HOURS.map(hour => (
+            <SelectItem key={hour} value={hour}>
+              {hour}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <span className="text-xs font-medium text-muted-foreground">h</span>
+      <Select
+        value={m}
+        onValueChange={newM => onChange(`${h || '00'}:${newM}`)}
+        disabled={disabled}
+      >
+        <SelectTrigger className="h-8 w-[76px]">
+          <SelectValue placeholder="mm" />
+        </SelectTrigger>
+        <SelectContent>
+          {MINUTES.map(min => (
+            <SelectItem key={min} value={min}>
+              {min}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <span className="text-xs font-medium text-muted-foreground">min</span>
+    </div>
+  )
+}
+
+export function ScheduleTimeBuilder({
+  value,
+  onChange,
+  classDays,
+  disabled,
+}: ScheduleTimeBuilderProps) {
+  const [mode, setMode] = useState<ScheduleMode>('same')
+  const [sameStart, setSameStart] = useState('')
+  const [sameEnd, setSameEnd] = useState('')
+  const [perDayTimes, setPerDayTimes] = useState<DayTimeEntry[]>([])
+  const legacyRef = useRef<string>('')
+  const [legacyDetected, setLegacyDetected] = useState(false)
+
+  // lastExternalValue tracks the last value we received externally (from the form).
+  // We use it to skip re-hydrating values that we ourselves emitted via onChange —
+  // without this, our own emit bounces back and re-triggers hydration.
+  const lastExternalValue = useRef<string | null | undefined>(undefined)
+
+  // Hydrate internal state from external value (edit mode / after save+refetch).
+  // Only runs when the incoming value truly changed from outside.
+  useEffect(() => {
+    // Skip if this is the same value we already processed
+    if (value === lastExternalValue.current) return
+    lastExternalValue.current = value
+
+    if (!value) {
+      setMode('same')
+      setSameStart('')
+      setSameEnd('')
+      setPerDayTimes([])
+      return
+    }
+
+    const parsed = parseClassTime(value)
+    if (!parsed) {
+      // Legacy free-text value — show badge, keep selects empty
+      if (!legacyRef.current) {
+        legacyRef.current = value
+        setLegacyDetected(true)
+      }
+      return
+    }
+
+    if (parsed.mode === 'same') {
+      setMode('same')
+      setSameStart(parsed.start)
+      setSameEnd(parsed.end)
+    } else {
+      setMode('different')
+      setPerDayTimes(parsed.entries)
+    }
+  }, [value])
+
+  // Sync per-day rows when classDays changes while in 'different' mode
+  useEffect(() => {
+    if (mode !== 'different') return
+    const selectedDays = parseClassDays(classDays)
+    const ordered = DAYS_ORDER.filter(d => selectedDays.has(d))
+    setPerDayTimes(prev => {
+      const existing = new Map(prev.map(e => [e.day, e]))
+      return ordered.map(
+        day => existing.get(day) ?? { day, start: '', end: '' }
+      )
+    })
+  }, [classDays, mode])
+
+  // Auto-reset to 'same' when all days are deselected
+  useEffect(() => {
+    if (mode === 'different' && parseClassDays(classDays).size === 0) {
+      setMode('same')
+    }
+  }, [classDays, mode])
+
+  // Emit the serialized value to the parent form.
+  // Called directly from user interaction handlers — not from an effect —
+  // so there's no risk of running with stale/intermediate state.
+  function emit(
+    nextMode: ScheduleMode,
+    nextStart: string,
+    nextEnd: string,
+    nextPerDay: DayTimeEntry[]
+  ) {
+    const serialized =
+      nextMode === 'same'
+        ? serializeSameTime(nextStart, nextEnd)
+        : serializePerDayTimes(nextPerDay)
+
+    // Incomplete input (e.g. only start filled, end still empty) — don't
+    // propagate an empty string to the form field. Clearing the field here
+    // would also poison lastExternalValue.current with "" and prevent the
+    // hydration effect from re-running when a valid value is loaded later.
+    if (!serialized) return
+
+    // Update our tracking ref so the hydrate effect skips this value when it
+    // bounces back from the form (React Hook Form calls render with new field.value).
+    lastExternalValue.current = serialized
+    onChange(serialized)
+  }
+
+  function handleSameStart(val: string) {
+    // val must be a full "HH:MM" string with a non-empty hour part
+    const [hPart] = val.split(':')
+    if (!hPart) return
+    setSameStart(val)
+    emit('same', val, sameEnd, perDayTimes)
+  }
+
+  function handleSameEnd(val: string) {
+    const [hPart] = val.split(':')
+    if (!hPart) return
+    setSameEnd(val)
+    emit('same', sameStart, val, perDayTimes)
+  }
+
+  function updateEntry(index: number, field: 'start' | 'end', val: string) {
+    const next = perDayTimes.map((e, i) =>
+      i === index ? { ...e, [field]: val } : e
+    )
+    setPerDayTimes(next)
+    emit('different', sameStart, sameEnd, next)
+  }
+
+  function handleModeChange(newMode: ScheduleMode) {
+    setMode(newMode)
+    if (newMode === 'different') {
+      const selectedDays = parseClassDays(classDays)
+      const ordered = DAYS_ORDER.filter(d => selectedDays.has(d))
+      const next = ordered.map(
+        day =>
+          perDayTimes.find(e => e.day === day) ?? { day, start: '', end: '' }
+      )
+      setPerDayTimes(next)
+      emit('different', sameStart, sameEnd, next)
+    } else {
+      emit('same', sameStart, sameEnd, perDayTimes)
+    }
+  }
+
+  const noDaysSelected = parseClassDays(classDays).size === 0
+
+  const preview =
+    mode === 'same'
+      ? serializeSameTime(sameStart, sameEnd)
+      : serializePerDayTimes(perDayTimes)
+
+  return (
+    <div className="space-y-3">
+      {/* Legacy value badge */}
+      {legacyDetected && (
+        <div className="flex items-center gap-2 rounded-md border border-amber-500/25 bg-amber-500/5 px-3 py-2">
+          <span className="shrink-0 text-xs font-medium text-amber-500/70">
+            Valor atual (formatação antiga)
+          </span>
+          <span className="truncate text-sm text-amber-200/60">
+            {legacyRef.current}
+          </span>
+        </div>
+      )}
+
+      {/* New value preview + replacement warning */}
+      {preview && (
+        <>
+          <input
+            readOnly
+            value={preview}
+            tabIndex={-1}
+            className="h-9 w-full cursor-default select-none rounded-md border border-input bg-muted px-3 py-1 text-sm text-muted-foreground shadow-sm"
+          />
+          {legacyDetected && (
+            <p className="text-xs text-amber-500/70">
+              ⚠ Este novo valor substituirá a formatação antiga ao salvar.
+            </p>
+          )}
+        </>
+      )}
+
+      <RadioGroup
+        value={mode}
+        onValueChange={v => handleModeChange(v as ScheduleMode)}
+        disabled={disabled}
+        className="flex flex-col gap-2 sm:flex-row sm:gap-6"
+      >
+        <div className="flex items-center gap-2">
+          <RadioGroupItem value="same" id="schedule-mode-same" />
+          <Label
+            htmlFor="schedule-mode-same"
+            className="cursor-pointer font-normal"
+          >
+            Mesmo horário para todos os dias
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <RadioGroupItem
+            value="different"
+            id="schedule-mode-different"
+            disabled={disabled || noDaysSelected}
+          />
+          <Label
+            htmlFor="schedule-mode-different"
+            className={`cursor-pointer font-normal ${noDaysSelected ? 'text-muted-foreground' : ''}`}
+          >
+            Horários diferentes por dia
+          </Label>
+        </div>
+      </RadioGroup>
+
+      {mode === 'same' && (
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+            <span className="w-10 shrink-0 text-xs text-muted-foreground">
+              Início
+            </span>
+            <TimeSelect
+              value={sameStart}
+              onChange={handleSameStart}
+              disabled={disabled}
+            />
+          </div>
+          <span className="px-1 text-sm text-muted-foreground">até</span>
+          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+            <span className="w-10 shrink-0 text-xs text-muted-foreground">
+              Fim
+            </span>
+            <TimeSelect
+              value={sameEnd}
+              onChange={handleSameEnd}
+              disabled={disabled}
+            />
+          </div>
+        </div>
+      )}
+
+      {mode === 'different' &&
+        (noDaysSelected ? (
+          <p className="text-sm text-muted-foreground">
+            Selecione os dias de aula acima para definir os horários.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {perDayTimes.map((entry, i) => (
+              <div
+                key={entry.day}
+                className="flex items-center gap-4 rounded-md border border-border bg-muted/30 px-4 py-3"
+              >
+                {/* Coluna esquerda — dia */}
+                <span className="w-8 shrink-0 text-sm font-semibold">
+                  {entry.day}
+                </span>
+
+                {/* Divisor */}
+                <div className="h-10 w-px shrink-0 bg-border" />
+
+                {/* Coluna direita — Início e Fim empilhados */}
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="w-10 shrink-0 text-xs text-muted-foreground">
+                      Início
+                    </span>
+                    <TimeSelect
+                      value={entry.start}
+                      onChange={val => updateEntry(i, 'start', val)}
+                      disabled={disabled}
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="w-10 shrink-0 text-xs text-muted-foreground">
+                      Fim
+                    </span>
+                    <TimeSelect
+                      value={entry.end}
+                      onChange={val => updateEntry(i, 'end', val)}
+                      disabled={disabled}
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+    </div>
+  )
+}

--- a/src/app/(private)/(app)/gorio/components/schedule-utils.ts
+++ b/src/app/(private)/(app)/gorio/components/schedule-utils.ts
@@ -1,0 +1,161 @@
+export const DAYS_ORDER = [
+  'Seg',
+  'Ter',
+  'Qua',
+  'Qui',
+  'Sex',
+  'Sáb',
+  'Dom',
+] as const
+
+export type DayAbbrev = (typeof DAYS_ORDER)[number]
+
+export interface DayTimeEntry {
+  day: string
+  start: string // "HH:MM" (24h, for input[type=time])
+  end: string // "HH:MM" (24h, for input[type=time])
+}
+
+export type ParsedClassTime =
+  | { mode: 'same'; start: string; end: string }
+  | { mode: 'different'; entries: DayTimeEntry[] }
+  | null
+
+// ---------------------------------------------------------------------------
+// classDays helpers
+// ---------------------------------------------------------------------------
+
+export function parseClassDays(value: string | null | undefined): Set<string> {
+  if (!value) return new Set()
+  return new Set(
+    value
+      .split(',')
+      .map(d => d.trim())
+      .filter(d => (DAYS_ORDER as readonly string[]).includes(d))
+  )
+}
+
+export function serializeClassDays(selected: Set<string>): string {
+  return DAYS_ORDER.filter(d => selected.has(d)).join(', ')
+}
+
+// ---------------------------------------------------------------------------
+// Time format helpers
+// ---------------------------------------------------------------------------
+
+// "17:30" → "17h30"  |  "17:00" → "17h"
+export function formatTimeToDisplay(timeStr: string): string {
+  if (!timeStr) return ''
+  const [hRaw, mRaw] = timeStr.split(':')
+  const h = Number.parseInt(hRaw, 10)
+  const m = Number.parseInt(mRaw ?? '0', 10)
+  if (Number.isNaN(h)) return ''
+  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, '0')}`
+}
+
+// "17h30" → "17:30"  |  "17h" → "17:00"  (for input[type=time])
+export function parseTimeFromDisplay(display: string): string {
+  if (!display) return ''
+  const match = display.match(/^(\d{1,2})h(\d{2})?$/)
+  if (!match) return ''
+  const h = match[1].padStart(2, '0')
+  const m = (match[2] ?? '00').padStart(2, '0')
+  return `${h}:${m}`
+}
+
+// ---------------------------------------------------------------------------
+// classTime serialize
+// ---------------------------------------------------------------------------
+
+// Mode 1: ("17:30", "19:00") → "17h30 até 19h00"
+export function serializeSameTime(start: string, end: string): string {
+  if (!start || !end) return ''
+  return `${formatTimeToDisplay(start)} até ${formatTimeToDisplay(end)}`
+}
+
+// Mode 2: DayTimeEntry[] → "Seg, Ter - 19h30 até 20h00 | Qui - 21h00 até 22h00"
+// Groups days with identical start+end; orders by DAYS_ORDER.
+export function serializePerDayTimes(entries: DayTimeEntry[]): string {
+  const complete = entries.filter(e => e.start && e.end)
+  if (complete.length === 0) return ''
+
+  // Group by "start|end" key, preserving canonical day order within each group
+  const groups = new Map<string, string[]>()
+  for (const entry of complete) {
+    const key = `${entry.start}|${entry.end}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(entry.day)
+  }
+
+  // Sort groups by the canonical index of their first day
+  const sortedGroups = [...groups.entries()].sort(([, daysA], [, daysB]) => {
+    const firstA = DAYS_ORDER.indexOf(daysA[0] as DayAbbrev)
+    const firstB = DAYS_ORDER.indexOf(daysB[0] as DayAbbrev)
+    return firstA - firstB
+  })
+
+  return sortedGroups
+    .map(([key, days]) => {
+      const [start, end] = key.split('|')
+      const sortedDays = [...days].sort(
+        (a, b) =>
+          DAYS_ORDER.indexOf(a as DayAbbrev) -
+          DAYS_ORDER.indexOf(b as DayAbbrev)
+      )
+      return `${sortedDays.join(', ')} - ${formatTimeToDisplay(start)} até ${formatTimeToDisplay(end)}`
+    })
+    .join(' | ')
+}
+
+// ---------------------------------------------------------------------------
+// classTime deserialize (for edit mode)
+// ---------------------------------------------------------------------------
+
+function parseSegment(
+  segment: string
+): { days: string[]; start: string; end: string } | null {
+  // Pattern: "DayList - startTime até endTime"
+  const withDays = segment.match(/^(.+?)\s+-\s+(.+?)\s+até\s+(.+)$/)
+  if (withDays) {
+    const days = withDays[1].split(',').map(d => d.trim())
+    return {
+      days,
+      start: parseTimeFromDisplay(withDays[2].trim()),
+      end: parseTimeFromDisplay(withDays[3].trim()),
+    }
+  }
+  return null
+}
+
+export function parseClassTime(
+  value: string | null | undefined
+): ParsedClassTime {
+  if (!value) return null
+
+  // Mode 1: "17h30 até 19h00" — no '|', no ' - '
+  if (!value.includes('|') && !value.includes(' - ')) {
+    const match = value.match(/^(.+?)\s+até\s+(.+)$/)
+    if (match) {
+      const start = parseTimeFromDisplay(match[1].trim())
+      const end = parseTimeFromDisplay(match[2].trim())
+      if (start && end) return { mode: 'same', start, end }
+    }
+    return null
+  }
+
+  // Mode 2: segments split by " | "
+  const segments = value.split(' | ')
+  const entries: DayTimeEntry[] = []
+  for (const seg of segments) {
+    const parsed = parseSegment(seg.trim())
+    if (!parsed) return null // malformed → leave state untouched
+    for (const day of parsed.days) {
+      entries.push({ day, start: parsed.start, end: parsed.end })
+    }
+  }
+  if (entries.length > 0) {
+    return { mode: 'different', entries }
+  }
+
+  return null
+}

--- a/src/app/(private)/(app)/gorio/empregabilidade/components/new-empregabilidade-form.tsx
+++ b/src/app/(private)/(app)/gorio/empregabilidade/components/new-empregabilidade-form.tsx
@@ -303,7 +303,7 @@ export const NewEmpregabilidadeForm = forwardRef<
       const uniqueNeighborhoods = Array.from(
         new Set(neighborhoodZone.map(n => n.bairro))
       )
-        .sort()
+        .sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }))
         .map(bairro => ({
           value: bairro,
           label: bairro,

--- a/src/app/(private)/(app)/gorio/oportunidades-mei/components/new-mei-opportunity-form.tsx
+++ b/src/app/(private)/(app)/gorio/oportunidades-mei/components/new-mei-opportunity-form.tsx
@@ -300,10 +300,12 @@ export const NewMEIOpportunityForm = forwardRef<
       const uniqueNeighborhoods = Array.from(
         new Set(neighborhoodZone.map(n => n.bairro))
       )
-      return uniqueNeighborhoods.sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' })).map(bairro => ({
-        value: bairro,
-        label: bairro,
-      }))
+      return uniqueNeighborhoods
+        .sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }))
+        .map(bairro => ({
+          value: bairro,
+          label: bairro,
+        }))
     }, [])
 
     // Track form changes for unsaved changes guard

--- a/src/app/(private)/(app)/gorio/oportunidades-mei/components/new-mei-opportunity-form.tsx
+++ b/src/app/(private)/(app)/gorio/oportunidades-mei/components/new-mei-opportunity-form.tsx
@@ -300,7 +300,7 @@ export const NewMEIOpportunityForm = forwardRef<
       const uniqueNeighborhoods = Array.from(
         new Set(neighborhoodZone.map(n => n.bairro))
       )
-      return uniqueNeighborhoods.sort().map(bairro => ({
+      return uniqueNeighborhoods.sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' })).map(bairro => ({
         value: bairro,
         label: bairro,
       }))

--- a/src/app/api/courses/[course-id]/approve/route.ts
+++ b/src/app/api/courses/[course-id]/approve/route.ts
@@ -3,6 +3,55 @@ import { cookies } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 
 /**
+ * Verifica se alguma turma do curso tem class_start_date anterior ao enrollment_start_date.
+ * Retorna uma mensagem de erro ou null se as datas estiverem consistentes.
+ */
+function validateCourseDates(courseData: any): string | null {
+  const enrollmentStart = courseData?.enrollment_start_date
+  if (!enrollmentStart) return null
+
+  const enrollmentStartDate = new Date(enrollmentStart)
+  if (Number.isNaN(enrollmentStartDate.getTime())) return null
+
+  // PRESENCIAL: locations[].schedules[].class_start_date
+  const locations: any[] = courseData?.locations ?? []
+  for (const location of locations) {
+    for (const schedule of location?.schedules ?? []) {
+      if (schedule?.class_start_date) {
+        const classStart = new Date(schedule.class_start_date)
+        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+          return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+        }
+      }
+    }
+  }
+
+  // ONLINE: remote_class pode ser array ou objeto com .schedules
+  const remoteClass = courseData?.remote_class
+  if (Array.isArray(remoteClass)) {
+    for (const schedule of remoteClass) {
+      if (schedule?.class_start_date) {
+        const classStart = new Date(schedule.class_start_date)
+        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+          return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+        }
+      }
+    }
+  } else if (remoteClass?.schedules) {
+    for (const schedule of remoteClass.schedules) {
+      if (schedule?.class_start_date) {
+        const classStart = new Date(schedule.class_start_date)
+        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+          return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+/**
  * NOVO - Endpoint para aprovar curso (Casa Civil)
  * Transição: in_review → approved
  */
@@ -24,8 +73,33 @@ export async function PUT(
       )
     }
 
-    // Chamar backend API
     const baseUrl = process.env.NEXT_PUBLIC_COURSES_BASE_API_URL
+
+    // Buscar dados atuais do curso para validar datas antes de aprovar
+    const courseResponse = await fetch(
+      `${baseUrl}/api/v1/courses/${courseId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken.value}`,
+        },
+      }
+    )
+
+    if (courseResponse.ok) {
+      const courseResult = await courseResponse.json()
+      const courseData = courseResult?.data ?? courseResult
+      const dateError = validateCourseDates(courseData)
+      if (dateError) {
+        return NextResponse.json(
+          { error: dateError, success: false },
+          { status: 422 }
+        )
+      }
+    }
+
+    // Chamar backend API
     const response = await fetch(
       `${baseUrl}/api/v1/courses/${courseId}/approve`,
       {

--- a/src/app/api/courses/[course-id]/approve/route.ts
+++ b/src/app/api/courses/[course-id]/approve/route.ts
@@ -19,7 +19,10 @@ function validateCourseDates(courseData: any): string | null {
     for (const schedule of location?.schedules ?? []) {
       if (schedule?.class_start_date) {
         const classStart = new Date(schedule.class_start_date)
-        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+        if (
+          !Number.isNaN(classStart.getTime()) &&
+          classStart < enrollmentStartDate
+        ) {
           return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
         }
       }
@@ -32,7 +35,10 @@ function validateCourseDates(courseData: any): string | null {
     for (const schedule of remoteClass) {
       if (schedule?.class_start_date) {
         const classStart = new Date(schedule.class_start_date)
-        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+        if (
+          !Number.isNaN(classStart.getTime()) &&
+          classStart < enrollmentStartDate
+        ) {
           return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
         }
       }
@@ -41,7 +47,10 @@ function validateCourseDates(courseData: any): string | null {
     for (const schedule of remoteClass.schedules) {
       if (schedule?.class_start_date) {
         const classStart = new Date(schedule.class_start_date)
-        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+        if (
+          !Number.isNaN(classStart.getTime()) &&
+          classStart < enrollmentStartDate
+        ) {
           return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
         }
       }

--- a/src/app/api/courses/[course-id]/publish/route.ts
+++ b/src/app/api/courses/[course-id]/publish/route.ts
@@ -3,6 +3,55 @@ import { cookies } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 
 /**
+ * Verifica se alguma turma do curso tem class_start_date anterior ao enrollment_start_date.
+ * Retorna uma mensagem de erro ou null se as datas estiverem consistentes.
+ */
+function validateCourseDates(courseData: any): string | null {
+  const enrollmentStart = courseData?.enrollment_start_date
+  if (!enrollmentStart) return null
+
+  const enrollmentStartDate = new Date(enrollmentStart)
+  if (Number.isNaN(enrollmentStartDate.getTime())) return null
+
+  // PRESENCIAL: locations[].schedules[].class_start_date
+  const locations: any[] = courseData?.locations ?? []
+  for (const location of locations) {
+    for (const schedule of location?.schedules ?? []) {
+      if (schedule?.class_start_date) {
+        const classStart = new Date(schedule.class_start_date)
+        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+          return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+        }
+      }
+    }
+  }
+
+  // ONLINE: remote_class pode ser array ou objeto com .schedules
+  const remoteClass = courseData?.remote_class
+  if (Array.isArray(remoteClass)) {
+    for (const schedule of remoteClass) {
+      if (schedule?.class_start_date) {
+        const classStart = new Date(schedule.class_start_date)
+        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+          return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+        }
+      }
+    }
+  } else if (remoteClass?.schedules) {
+    for (const schedule of remoteClass.schedules) {
+      if (schedule?.class_start_date) {
+        const classStart = new Date(schedule.class_start_date)
+        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+          return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+/**
  * NOVO - Endpoint para publicar curso
  * Transição: approved → published
  */
@@ -24,8 +73,33 @@ export async function PUT(
       )
     }
 
-    // Chamar backend API
     const baseUrl = process.env.NEXT_PUBLIC_COURSES_BASE_API_URL
+
+    // Buscar dados atuais do curso para validar datas antes de publicar
+    const courseResponse = await fetch(
+      `${baseUrl}/api/v1/courses/${courseId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken.value}`,
+        },
+      }
+    )
+
+    if (courseResponse.ok) {
+      const courseResult = await courseResponse.json()
+      const courseData = courseResult?.data ?? courseResult
+      const dateError = validateCourseDates(courseData)
+      if (dateError) {
+        return NextResponse.json(
+          { error: dateError, success: false },
+          { status: 422 }
+        )
+      }
+    }
+
+    // Chamar backend API
     const response = await fetch(
       `${baseUrl}/api/v1/courses/${courseId}/publish`,
       {

--- a/src/app/api/courses/[course-id]/publish/route.ts
+++ b/src/app/api/courses/[course-id]/publish/route.ts
@@ -19,7 +19,10 @@ function validateCourseDates(courseData: any): string | null {
     for (const schedule of location?.schedules ?? []) {
       if (schedule?.class_start_date) {
         const classStart = new Date(schedule.class_start_date)
-        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+        if (
+          !Number.isNaN(classStart.getTime()) &&
+          classStart < enrollmentStartDate
+        ) {
           return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
         }
       }
@@ -32,7 +35,10 @@ function validateCourseDates(courseData: any): string | null {
     for (const schedule of remoteClass) {
       if (schedule?.class_start_date) {
         const classStart = new Date(schedule.class_start_date)
-        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+        if (
+          !Number.isNaN(classStart.getTime()) &&
+          classStart < enrollmentStartDate
+        ) {
           return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
         }
       }
@@ -41,7 +47,10 @@ function validateCourseDates(courseData: any): string | null {
     for (const schedule of remoteClass.schedules) {
       if (schedule?.class_start_date) {
         const classStart = new Date(schedule.class_start_date)
-        if (!Number.isNaN(classStart.getTime()) && classStart < enrollmentStartDate) {
+        if (
+          !Number.isNaN(classStart.getTime()) &&
+          classStart < enrollmentStartDate
+        ) {
           return 'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'
         }
       }

--- a/src/components/ui/datetime-picker.tsx
+++ b/src/components/ui/datetime-picker.tsx
@@ -22,6 +22,7 @@ interface DateTimePickerProps {
   className?: string
   id?: string
   disablePastDates?: boolean
+  minDate?: Date
 }
 
 export function DateTimePicker({
@@ -32,6 +33,7 @@ export function DateTimePicker({
   className,
   id,
   disablePastDates = false,
+  minDate,
 }: DateTimePickerProps) {
   const [open, setOpen] = React.useState(false)
   const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(
@@ -43,11 +45,6 @@ export function DateTimePicker({
     }
     return '23:59:59'
   })
-
-  // Calculate year range: 5 years back and 5 years forward from current year
-  const currentYear = new Date().getFullYear()
-  const fromYear = currentYear - 5
-  const toYear = currentYear + 5
 
   // Sync with external value changes
   React.useEffect(() => {
@@ -135,20 +132,21 @@ export function DateTimePicker({
               selected={selectedDate}
               captionLayout="dropdown"
               onSelect={handleDateSelect}
-              initialFocus
-              fromYear={fromYear}
-              toYear={toYear}
               disabled={date => {
+                const compareDate = new Date(date)
+                compareDate.setHours(0, 0, 0, 0)
                 if (disablePastDates) {
                   const today = new Date()
                   today.setHours(0, 0, 0, 0)
-                  const compareDate = new Date(date)
-                  compareDate.setHours(0, 0, 0, 0)
-                  return compareDate < today
+                  if (compareDate < today) return true
+                }
+                if (minDate) {
+                  const min = new Date(minDate)
+                  min.setHours(0, 0, 0, 0)
+                  if (compareDate < min) return true
                 }
                 return false
               }}
-              fromDate={disablePastDates ? new Date() : undefined}
             />
           </PopoverContent>
         </Popover>

--- a/src/lib/date-validation.ts
+++ b/src/lib/date-validation.ts
@@ -12,3 +12,16 @@ export function isDateInFuture(date: Date): boolean {
  */
 export const FUTURE_DATE_ERROR_MESSAGE =
   'A data selecionada deve ser futura. Não é possível selecionar datas passadas.'
+
+/**
+ * Verifica se a data de início das aulas é igual ou posterior ao início das inscrições
+ */
+export function isClassStartAfterEnrollmentStart(
+  classStartDate: Date,
+  enrollmentStartDate: Date
+): boolean {
+  return classStartDate >= enrollmentStartDate
+}
+
+export const CLASS_BEFORE_ENROLLMENT_ERROR =
+  'A data de início das aulas deve ser igual ou posterior ao início das inscrições.'


### PR DESCRIPTION
## Context

Three independent improvements to the Gorio course management module:

1. **Date validation on courses** — class start/end dates were not being validated against enrollment dates, allowing inconsistent data to be saved, approved, and published.
2. **Neighborhood sorting** — neighborhood dropdowns across Gorio forms (courses, empregabilidade, oportunidades MEI) were sorting incorrectly due to missing Portuguese locale support.
3. **Class schedule fields** — the `classTime` and `classDays` fields were free-text inputs with no structure, causing display inconsistencies and broken edit flows. The "same time for all days" mode was broken on load due to a Radix Select firing `onValueChange` with stale closure values during hydration.

---

## What Was Done

### Date Validation
- Added `validateCourseDates()` to the `/approve` and `/publish` API routes — blocks approval/publication if any schedule has a class start date before the enrollment start date (422 response).
- Added `superRefine` to the course form Zod schema with per-field path errors for class start/end date validation.
- `DateTimePicker` gained a `minDate` prop; date pickers for class end dates now enforce `minDate = classStartDate`.
- Added `useEffect` that auto-corrects class dates when enrollment start date changes.
- Extracted reusable validation helpers to `src/lib/date-validation.ts`.

### Neighborhood Sorting
- Replaced `.sort()` with `.sort((a, b) => a.localeCompare(b, 'pt-BR'))` in `new-course-form.tsx`, `new-empregabilidade-form.tsx`, and `new-mei-opportunity-form.tsx`.

### Class Schedule Fields (new components)
- **`schedule-utils.ts`** — parse/serialize utilities for structured `classDays` (`"Seg, Ter, Qua"`) and `classTime` (`"17h30 até 19h"` for same-time mode; `"Seg, Ter - 17h30 até 19h | Qui - 21h até 22h"` for per-day mode).
- **`class-days-picker.tsx`** — checkbox-based day selector with legacy free-text detection and migration warning.
- **`schedule-time-builder.tsx`** — dual-mode time picker (same time for all days / different time per day), with hydration from existing values and legacy value support. Fixed a Radix Select stale closure bug by guarding `handleSameStart`/`handleSameEnd` against invalid `":00"` values fired during programmatic state updates.
- `new-course-form.tsx` updated to use the new components in place of the old free-text inputs.
