### PR TITLE
fix: corrige endereço do Prometheus no AnalysisTemplate de produção

### DIFF
--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -146,7 +146,7 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code!~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(1)
     - name: error-rate
@@ -155,6 +155,6 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code=~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(0)


### PR DESCRIPTION
## Problema

O AnalysisTemplate `portal-interno-success-rate` usa:
```
http://prometheus.istio-system.svc.cluster.local:9090
```

Mas o service `prometheus` **não existe** no cluster de produção — apenas `prometheus-server`. Isso causava falha DNS em todas as consultas do canary analysis, abortando o rollout.

```
dial tcp: lookup prometheus.istio-system.svc.cluster.local: no such host
```

## Fix

Corrige o `address` das métricas `success-rate` e `error-rate` para:
```
http://prometheus-server.istio-system.svc.cluster.local:9090
```

## Contexto

- Diagnosticado via `kubectl get svc -A --context=gke_rj-superapp_us-central1_application | grep prometheus`
- Único service disponível em prod: `prometheus-server` (istio-system)
- Impactou o release `v1.0.6` (run #26195026828)