### PR TITLE
ref(empregabilidade): remove unused accessibility option from form sc…

### DIFF
--- a/src/app/(private)/(app)/gorio/empregabilidade/components/new-empregabilidade-form.tsx
+++ b/src/app/(private)/(app)/gorio/empregabilidade/components/new-empregabilidade-form.tsx
@@ -114,7 +114,6 @@ const formSchema = z.object({
   vaga_pcd: z.boolean().optional(),
   acessibilidade_pcd: z
     .enum([
-      EmpregabilidadeAcessibilidadePCD.AcessibilidadeParaPCD,
       EmpregabilidadeAcessibilidadePCD.AcessibilidadePreferencialPCD,
       EmpregabilidadeAcessibilidadePCD.AcessibilidadeExclusivoPCD,
     ])
@@ -348,10 +347,6 @@ export const NewEmpregabilidadeForm = forwardRef<
     )
 
     const acessibilidadePcdOptions = [
-      {
-        value: EmpregabilidadeAcessibilidadePCD.AcessibilidadeParaPCD,
-        label: 'Para PcD',
-      },
       {
         value: EmpregabilidadeAcessibilidadePCD.AcessibilidadePreferencialPCD,
         label: 'Preferencial PcD',


### PR DESCRIPTION
…hema

Eliminated the 'Para PcD' option from the accessibility selection in the NewEmpregabilidadeForm component to streamline the form and improve clarity.