### PR TITLE
fix(editor): remove extensao 'link' duplicada no Tiptap

### DIFF
--- a/src/components/blocks/editor-md/markdown-editor.tsx
+++ b/src/components/blocks/editor-md/markdown-editor.tsx
@@ -50,6 +50,9 @@ export function MarkdownEditor({
             horizontalRule: false,
             bulletList: false,
             orderedList: false,
+            // Link is provided by our custom Link.configure() below; disable
+            // StarterKit's bundled Link to avoid a duplicate 'link' extension.
+            link: false,
           }),
           Link.configure({
             openOnClick: false,
@@ -77,6 +80,9 @@ export function MarkdownEditor({
               keepMarks: true,
               keepAttributes: false,
             },
+            // Link is provided by our custom Link.configure() below; disable
+            // StarterKit's bundled Link to avoid a duplicate 'link' extension.
+            link: false,
           }),
           Link.configure({
             openOnClick: false,

--- a/src/components/blocks/editor-md/markdown-viewer.tsx
+++ b/src/components/blocks/editor-md/markdown-viewer.tsx
@@ -19,7 +19,8 @@ export function MarkdownViewer({ content, className }: MarkdownViewerProps) {
   const editor = useEditor({
     immediatelyRender: false,
     extensions: [
-      StarterKit,
+      // Disable StarterKit's bundled Link; we register our own below.
+      StarterKit.configure({ link: false }),
       Link.configure({
         openOnClick: true,
         HTMLAttributes: {


### PR DESCRIPTION
O @tiptap/starter-kit@3.27.3 ja empacota a extensao Link (registra o nome 'link'). O markdown-editor.tsx e o markdown-viewer.tsx tambem adicionavam Link.configure() por cima, entao 'link' era registrado duas vezes, gerando o warning no console: [tiptap warn]: Duplicate extension names found: ['link'].

Fix: desliga o Link empacotado do StarterKit (link: false) e mantem o nosso Link.configure() (openOnClick + HTMLAttributes) como fonte unica.