### PR TITLE
fix(mei): parse timestamps by instant in opportunities table

### DIFF
--- a/src/app/(private)/(app)/gorio/oportunidades-mei/components/oportunidades-mei-data-table.tsx
+++ b/src/app/(private)/(app)/gorio/oportunidades-mei/components/oportunidades-mei-data-table.tsx
@@ -204,6 +204,21 @@ function CNAEActivityDisplay({ cnaeIds }: { cnaeIds: string[] }) {
   )
 }
 
+// Converts an API ISO timestamp to a local YYYY-MM-DD key (browser timezone).
+// We derive the calendar day from the parsed instant instead of slicing the raw
+// string: the backend now serializes timestamps with a -03:00 offset instead of
+// UTC "Z", and `iso.split('T')[0]` would read a different day depending on that
+// offset. Parsing to an instant first makes the day stable across serializations.
+function toLocalDateKey(iso: string | null | undefined): string | null {
+  if (!iso) return null
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return null
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 // Helper function to transform API data to OportunidadeMEI format
 function transformAPIToDataTable(
   opportunity: ModelsOportunidadeMEI
@@ -217,12 +232,11 @@ function transformAPIToDataTable(
     title: String(opp.titulo || ''),
     activity: '', // Will be populated by CNAEActivityDisplay component
     offeredBy: String(opp.orgao_id || ''), // Store orgao_id as cd_ua for DepartmentName
-    publishedAt:
-      opp.status === 'draft' ? null : opp.created_at?.split('T')?.[0] || null,
-    expiresAt: String(opp.data_expiracao?.split('T')?.[0] || ''),
+    publishedAt: opp.status === 'draft' ? null : toLocalDateKey(opp.created_at),
+    expiresAt: toLocalDateKey(opp.data_expiracao) || '',
     status: opp.status as OportunidadeMEIStatus,
     managingOrgan: String(opp.orgao_id || ''), // Store orgao_id as cd_ua
-    lastUpdate: String(opp.updated_at?.split('T')?.[0] || ''),
+    lastUpdate: toLocalDateKey(opp.updated_at) || '',
     cnaeIds, // Store cnae_ids for the component
   }
 }


### PR DESCRIPTION
## O que muda

A tabela de Oportunidades MEI (`oportunidades-mei-data-table.tsx`) derivava o **dia** das colunas **Data de publicação**, **Expira em** e última atualização fatiando a string crua da API (`iso.split('T')[0]`).

Depois que a [app-go-api passou a serializar timestamps com offset `-03:00`](https://github.com/prefeitura-rio/app-go-api/commit/0631cd94aa79b8b20b88f6380eab7f3640a7ea06) em vez de UTC `Z` (mesmo instante, string diferente), esse fatiamento passa a ler um **dia diferente** para timestamps noturnos (21h–23h59 BRT):

| Serialização do backend | `split('T')[0]` lê | Célula |
| --- | --- | --- |
| Antigo `2026-08-21T02:59:59Z` | `2026-08-21` | **21/08 ❌** |
| Novo `2026-08-20T23:59:59-03:00` | `2026-08-20` | **20/08 ✅** |

Substituo o fatiamento por `toLocalDateKey(iso)`, que **parseia o instante** e extrai um `YYYY-MM-DD` local — mesmo padrão já usado na tabela de cursos (`courses/page.tsx`). O dia passa a ser estável independente de o backend mandar `Z` ou `-03:00`, e deixa de depender do formato de serialização.

## Por que

- **Correção do bug histórico:** sob o backend antigo (`Z`), oportunidades com expiração no fim do dia apareciam com **+1 dia** nas colunas de data (e na ordenação/filtro por intervalo).
- **Robustez:** o deploy do timezone na API já "mascarou" o sintoma no staging (com `-03:00` o `split` acerta por coincidência); esta mudança garante o dia correto **independente** do formato, evitando regressão se algum endpoint/rollback voltar a mandar `Z`.
- É o **único** ponto do client afetado pela mudança de timezone — o resto do app já parseia por instante (`new Date(...)`), então não muda.

<img width="1568" height="783" alt="image" src="https://github.com/user-attachments/assets/23d5ddcb-0eab-47d7-b236-4a9fa3ffb106" />

No print acima, a expiração foi setada em 27/07 23:59 (caso noturno). Armazenada como 2026-07-27T23:59:59-03:00, o código corrigido renderiza 27/07/2026 — o dia certo de Brasília. Sob o backend antigo (Z) + código com bug, essa mesma linha teria virado 28/07 (o +1 dia).