### PR TITLE
fix(dates): pin America/Sao_Paulo in date formatters

### DIFF
--- a/src/app/(private)/(app)/gorio/empregabilidade/[empregabilidade-id]/page.tsx
+++ b/src/app/(private)/(app)/gorio/empregabilidade/[empregabilidade-id]/page.tsx
@@ -37,6 +37,7 @@ import { UnsavedChangesGuard } from '@/components/unsaved-changes-guard'
 import { useHeimdallUserContext } from '@/contexts/heimdall-user-context'
 import { useVaga } from '@/hooks/use-vaga'
 import { fromApiInformacaoComplementar } from '@/lib/converters/empregabilidade'
+import { formatDateBR } from '@/lib/format'
 import {
   type VagaStatus,
   vagaStatusConfig,
@@ -45,8 +46,6 @@ import {
   canDeleteVagaWithStatus,
   hasEditorComCuradoriaRestrictions,
 } from '@/types/heimdall-roles'
-import { format } from 'date-fns'
-import { ptBR } from 'date-fns/locale'
 import {
   Ban,
   Edit,
@@ -871,10 +870,7 @@ export default function EmpregabilidadeDetailPage({
                 )}
                 {vaga.created_at && (
                   <span className="text-sm text-muted-foreground">
-                    Criada em{' '}
-                    {format(new Date(vaga.created_at), 'dd/MM/yyyy', {
-                      locale: ptBR,
-                    })}
+                    Criada em {formatDateBR(vaga.created_at)}
                   </span>
                 )}
                 {vaga.contratante?.nome_fantasia && (

--- a/src/app/(private)/(app)/gorio/empregabilidade/components/empregabilidade-data-table.tsx
+++ b/src/app/(private)/(app)/gorio/empregabilidade/components/empregabilidade-data-table.tsx
@@ -60,6 +60,7 @@ import { useHeimdallUserContext } from '@/contexts/heimdall-user-context'
 import { useDebouncedCallback } from '@/hooks/use-debounced-callback'
 import { useEmpregabilidadeVagas } from '@/hooks/use-empregabilidade-vagas'
 import type { EmpregabilidadeVaga } from '@/http-gorio/models'
+import { formatDateBR } from '@/lib/format'
 import {
   type VagaStatus,
   vagaStatusConfig,
@@ -664,11 +665,10 @@ export function EmpregabilidadeDataTable() {
           if (!timestamp)
             return <span className="text-muted-foreground">Não informado</span>
 
-          const date = new Date(timestamp)
           return (
             <div className="flex items-center gap-2">
               <Calendar className="h-4 w-4 text-muted-foreground" />
-              <span>{date.toLocaleDateString('pt-BR')}</span>
+              <span>{formatDateBR(timestamp)}</span>
             </div>
           )
         },
@@ -716,11 +716,10 @@ export function EmpregabilidadeDataTable() {
               <span className="text-muted-foreground">Sem data limite</span>
             )
 
-          const date = new Date(timestamp)
           return (
             <div className="flex items-center gap-2">
               <Calendar className="h-4 w-4 text-muted-foreground" />
-              <span>{date.toLocaleDateString('pt-BR')}</span>
+              <span>{formatDateBR(timestamp)}</span>
             </div>
           )
         },

--- a/src/app/(private)/(app)/gorio/empregabilidade/empresas/[cnpj]/page.tsx
+++ b/src/app/(private)/(app)/gorio/empregabilidade/empresas/[cnpj]/page.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useHeimdallUserContext } from '@/contexts/heimdall-user-context'
 import { useEmpresa } from '@/hooks/use-empresa'
+import { formatDateBR } from '@/lib/format'
 import { Building2, Calendar, Globe, Pencil } from 'lucide-react'
 import Link from 'next/link'
 import { use } from 'react'
@@ -75,8 +76,7 @@ export default function ViewEmpresaPage({
    */
   const formatDate = (value: string | undefined): string => {
     if (!value) return 'Não informado'
-    const date = new Date(value)
-    return date.toLocaleString('pt-BR', {
+    return formatDateBR(value, {
       dateStyle: 'short',
       timeStyle: 'short',
     })

--- a/src/app/(private)/(app)/gorio/empregabilidade/empresas/page.tsx
+++ b/src/app/(private)/(app)/gorio/empregabilidade/empresas/page.tsx
@@ -22,6 +22,7 @@ import {
 import { useHeimdallUserContext } from '@/contexts/heimdall-user-context'
 import { useEmpresas } from '@/hooks/use-empresas'
 import type { EmpregabilidadeEmpresa } from '@/http-gorio/models'
+import { formatDateBR } from '@/lib/format'
 import {
   type Column,
   type ColumnDef,
@@ -272,11 +273,10 @@ export default function EmpresasPage() {
           if (!timestamp)
             return <span className="text-muted-foreground">Não informado</span>
 
-          const date = new Date(timestamp)
           return (
             <div className="flex items-center gap-2">
               <Calendar className="h-4 w-4 text-muted-foreground" />
-              <span>{date.toLocaleDateString('pt-BR')}</span>
+              <span>{formatDateBR(timestamp)}</span>
             </div>
           )
         },

--- a/src/app/(private)/(app)/gorio/oportunidades-mei/components/oportunidades-mei-data-table.tsx
+++ b/src/app/(private)/(app)/gorio/oportunidades-mei/components/oportunidades-mei-data-table.tsx
@@ -53,6 +53,7 @@ import {
   useMEIOpportunities,
 } from '@/hooks/use-mei-opportunities'
 import type { ModelsOportunidadeMEI } from '@/http-gorio/models'
+import { APP_TIME_ZONE } from '@/lib/format'
 import {
   type Column,
   type ColumnDef,
@@ -204,19 +205,23 @@ function CNAEActivityDisplay({ cnaeIds }: { cnaeIds: string[] }) {
   )
 }
 
-// Converts an API ISO timestamp to a local YYYY-MM-DD key (browser timezone).
+// Converts an API ISO timestamp to a YYYY-MM-DD key in Rio's timezone.
 // We derive the calendar day from the parsed instant instead of slicing the raw
-// string: the backend now serializes timestamps with a -03:00 offset instead of
-// UTC "Z", and `iso.split('T')[0]` would read a different day depending on that
-// offset. Parsing to an instant first makes the day stable across serializations.
+// string (`iso.split('T')[0]`), which would read a different day depending on the
+// -03:00 offset the backend now serializes. We also pin APP_TIME_ZONE instead of
+// using the runtime zone (getFullYear/getDate): SSR runs on UTC pods, where a
+// late-night `-03:00` instant would roll over to the next day. `en-CA` formats
+// as YYYY-MM-DD, so the key stays stable across serializations and runtimes.
 function toLocalDateKey(iso: string | null | undefined): string | null {
   if (!iso) return null
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return null
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: APP_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date)
 }
 
 // Helper function to transform API data to OportunidadeMEI format

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -15,3 +15,31 @@ export function formatDate(
     return ''
   }
 }
+
+// Rio de Janeiro timezone. Pin it when formatting API instants so the calendar
+// day is stable across runtimes: the backend serializes timestamps with a
+// -03:00 offset (e.g. "2026-07-30T23:59:59-03:00"), and formatting without a
+// fixed timeZone reads the browser/OS zone — a UTC pod (SSR/staging) would show
+// the next day (31/07) while localhost (-03:00) shows 30/07.
+export const APP_TIME_ZONE = 'America/Sao_Paulo'
+
+// Formats a date as pt-BR pinned to APP_TIME_ZONE. Defaults to dd/MM/yyyy;
+// pass Intl options (e.g. { dateStyle: 'short', timeStyle: 'short' }) to override.
+export function formatDateBR(
+  date: Date | string | number | null | undefined,
+  opts: Intl.DateTimeFormatOptions = {}
+) {
+  if (!date && date !== 0) return ''
+
+  const parsed = new Date(date)
+  if (Number.isNaN(parsed.getTime())) return ''
+
+  try {
+    return new Intl.DateTimeFormat('pt-BR', {
+      timeZone: APP_TIME_ZONE,
+      ...opts,
+    }).format(parsed)
+  } catch (_err) {
+    return ''
+  }
+}


### PR DESCRIPTION
## Contexto

A API (app-go-api) passou a serializar timestamps com offset de Brasília (`-03:00`) em vez de UTC (`...Z`) — mesmo instante, string diferente. Os formatadores de data que dependiam do timezone do **runtime** passaram a divergir entre ambientes:

- **localhost** (TZ `America/Sao_Paulo`, `-03:00`) → dia correto
- **staging** (pod SSR em **UTC**) → dia seguinte

Exemplo real: uma vaga expirando em `2026-07-30T23:59:59-03:00` aparecia como **30/07** no localhost e **31/07** no staging.

## Causa raiz

`toLocaleDateString`/`toLocaleString`, o `format` do date-fns e o helper `toLocalDateKey` do MEI (via `getFullYear/getMonth/getDate`) usam o timezone do processo. No pod UTC, o instante `...T02:59:59Z` cai no dia 31.

## Mudanças

Novo helper centralizado em `src/lib/format.ts`:

- `APP_TIME_ZONE = 'America/Sao_Paulo'`
- `formatDateBR(date, opts?)` — `Intl.DateTimeFormat('pt-BR')` com `timeZone` fixo (default `dd/MM/yyyy`)

Aplicado em:

| Arquivo | Ajuste |
| --- | --- |
| `empregabilidade/components/empregabilidade-data-table.tsx` | colunas **Data de criação** e **Expira em** (`data_limite`) |
| `empregabilidade/empresas/page.tsx` | coluna Data de criação |
| `empregabilidade/empresas/[cnpj]/page.tsx` | criado/atualizado em |
| `empregabilidade/[empregabilidade-id]/page.tsx` | "Criada em" (remove `format`/`ptBR` do date-fns órfãos) |
| `oportunidades-mei/components/oportunidades-mei-data-table.tsx` | `toLocalDateKey` agora deriva o dia via `Intl.DateTimeFormat('en-CA', { timeZone: APP_TIME_ZONE })` |

> A tabela MEI já tinha sido parcialmente corrigida em `277f10e` (já em `main`), que resolveu o slicing `split('T')[0]` mas ainda dependia do timezone do runtime. Esta PR completa o fix para o cenário SSR/pod UTC.

## Verificação

- `npm run typecheck` ✅
- Reprodução sob `TZ=UTC` (simulando o pod) com o instante reportado
  `2026-07-30T23:59:59-03:00`:

  | | Sem fix | Com fix |
  | --- | --- | --- |
  | empregabilidade (`toLocaleDateString` → `formatDateBR`) | `31/07/2026` ❌ | `30/07/2026` ✅ |
  | MEI chave (`getDate` → `en-CA`+timeZone) | `2026-07-31` ❌ | `2026-07-30` ✅ |

- Vaga de reprodução: `b14918be-8...` *(id do report original)*

## Notas

- Sem mudança no write path (segue enviando `Z`; backend aceita ambos).
- Origem: mesmo bug reportado primeiro no superapp (`emprego-utils.ts`).